### PR TITLE
Fix line ending problems and add more info

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@
  * @type {import('prettier').Options}
  */
 module.exports = {
-	// Overridden rules
+	// better for a11y + allows for personalized indentation locally
 	useTabs: true,
+
+	// sensible default
 	printWidth: 110,
 
-	// Default rules from Prettier 3.2.5
+	// allow CRLF locally on windows
+	// MUST SET "* text=auto" in .gitattributes (!)
+	endOfLine: "auto",
+
+	// Default rules from Prettier 3.2.5 below
 	tabWidth: 2,
 	semi: true,
 	singleQuote: false,
@@ -25,7 +31,6 @@ module.exports = {
 	proseWrap: "preserve",
 	htmlWhitespaceSensitivity: "css",
 	vueIndentScriptAndStyle: false,
-	endOfLine: "lf",
 	embeddedLanguageFormatting: "auto",
 	singleAttributePerLine: false,
 };


### PR DESCRIPTION
Vi fixar line endings med .gitattributes, så vi måste låta prettier tycka att CRLF är okej lokalt.
https://prettier.io/docs/en/options.html#end-of-line
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

Lade till lite mer info om varför vi har skrivit över de regler som vi har gjort.