### PR TITLE
chore: replace deprecated read-package-engines-version-actions with node-version-file

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -18,14 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Read node and npm versions from package.json
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
-
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
+          node-version-file: 'package.json'
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          node-version-file: "package.json"
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Read node and npm versions from package.json
-        uses: skjnldsv/read-package-engines-version-actions@v3
-        id: package-engines-versions
-
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
+          node-version-file: 'package.json'
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version-file: 'package.json'
+          node-version-file: "package.json"
 
       - run: npm ci
 


### PR DESCRIPTION
## Problem
`skjnldsv/read-package-engines-version-actions` runs on Node 20 and is deprecated (no Node 24 release). It will stop working.

## Fix
Drop the action; use `actions/setup-node`'s native `node-version-file` input pointing at `package.json`, which reads `engines.node` directly. No downstream output (`npmVersion`) was used. Same approach as Caspeco/AccessManagement#760.

> Note: `release.yml` is only triggered on GitHub releases, so it won't be exercised by this PR's CI — correctness rests on the diff matching the proven pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Anders Hassis <anders.hassis@caspeco.se>